### PR TITLE
readme: add note about minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ At some point the various application might get separated out in to their own pa
 
 ## Tools
 
+> requires `go1.16` or later
+
 ```
 $> make cli
 go build -mod vendor -o bin/assign-parent cmd/assign-parent/main.go


### PR DESCRIPTION
Prior to [go1.16](https://go.dev/blog/go1.16) the `make cli` command emits the following errors:

```
make cli
go build -mod vendor -o bin/assign-geometry cmd/assign-geometry/main.go
# github.com/whosonfirst/go-ioutil
vendor/github.com/whosonfirst/go-ioutil/readseekcloser.go:27:41: undefined: io.ReadSeekCloser
vendor/github.com/whosonfirst/go-ioutil/readseekcloser.go:34:7: undefined: io.ReadSeekCloser
vendor/github.com/whosonfirst/go-ioutil/readseekcloser.go:35:14: undefined: io.ReadSeekCloser
vendor/github.com/whosonfirst/go-ioutil/readseekcloser.go:110:15: undefined: io.ReadAll
# github.com/whosonfirst/go-writer
vendor/github.com/whosonfirst/go-writer/file.go:74:19: undefined: os.CreateTemp
vendor/github.com/whosonfirst/go-writer/null.go:29:17: undefined: io.Discard
make: *** [cli] Error 2
```

<img width="1084" alt="Screenshot 2021-08-19 at 11 22 32" src="https://user-images.githubusercontent.com/738069/130043986-f92622b5-0fdb-464a-980c-9709d526287e.png">
