### PR TITLE
deps: update whosonfirst/go-reader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,14 @@ require (
 	github.com/sfomuseum/go-flags v0.8.2
 	github.com/tidwall/gjson v1.8.0
 	github.com/tidwall/sjson v1.1.6
-	github.com/whosonfirst/go-reader v0.5.0
+	github.com/whosonfirst/go-reader v0.8.0
 	github.com/whosonfirst/go-whosonfirst-export/v2 v2.3.0
 	github.com/whosonfirst/go-whosonfirst-iterate v1.1.1
 	github.com/whosonfirst/go-whosonfirst-reader v0.0.2
 	github.com/whosonfirst/go-whosonfirst-spatial v0.0.56
 	github.com/whosonfirst/go-whosonfirst-spatial-hierarchy v0.0.1
 	github.com/whosonfirst/go-whosonfirst-spatial-sqlite v0.0.39
+	github.com/whosonfirst/go-whosonfirst-uri v1.0.1
 	github.com/whosonfirst/go-whosonfirst-writer v0.2.2
 	github.com/whosonfirst/go-writer v0.5.0
 	github.com/whosonfirst/go-writer-featurecollection v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/whosonfirst/go-reader v0.4.0 h1:9RQEVL+UYUbIuzj4oxSR9bd/sNIQ53/1jePNh
 github.com/whosonfirst/go-reader v0.4.0/go.mod h1:ffg8ww1158rNNqStFx64EGmDL5m5WZPsoMqR6wohOWE=
 github.com/whosonfirst/go-reader v0.5.0 h1:nx+ai0F6JXouw+7Dln34dmYglw+3sQ6sG4JZGOJ/sqA=
 github.com/whosonfirst/go-reader v0.5.0/go.mod h1:4ou/wZUss2CDZp27QK5ySDc8p98GVWvUiqqmwEprjgk=
+github.com/whosonfirst/go-reader v0.8.0 h1:Jo0KdHIncPH9AonNPC8Q8Hlx2PT9TgsBe3o83uP+Ci8=
+github.com/whosonfirst/go-reader v0.8.0/go.mod h1:6byB+UfZFNLYFqgsC/EKxTnKY8ahNgGHhUJsTrv1Jig=
 github.com/whosonfirst/go-rfc-5646 v0.1.0 h1:HNFPAem6v5De61PXLgbGzx9tfNOP83AAkVvm9WAddJY=
 github.com/whosonfirst/go-rfc-5646 v0.1.0/go.mod h1:JZj//FV9YeV3fkyOY/82V53EMLQXwRwNPuQIGs8BUmo=
 github.com/whosonfirst/go-sanitize v0.1.0 h1:ygSqCnakwdzH/m8UEa15zXGDsoo5/JJeRkgmAjXZrBU=

--- a/vendor/github.com/whosonfirst/go-reader/Makefile
+++ b/vendor/github.com/whosonfirst/go-reader/Makefile
@@ -1,0 +1,2 @@
+cli:
+	go build -mod vendor -o bin/read cmd/read/main.go

--- a/vendor/github.com/whosonfirst/go-reader/doc.go
+++ b/vendor/github.com/whosonfirst/go-reader/doc.go
@@ -1,0 +1,46 @@
+// Example:
+//
+// 	package main
+//
+// 	import (
+//	 	"context"
+// 		"github.com/whosonfirst/go-reader"
+// 		"io"
+//	 	"os"
+// 	)
+//
+//	 func main() {
+//	 	ctx := context.Background()
+//	 	r, _ := reader.NewReader(ctx, "fs:///usr/local/data")
+//	 	fh, _ := r.Read(ctx, "example.txt")
+//	 	defer fh.Close()
+//	 	io.Copy(os.Stdout, fh)
+//	 }
+//
+// Package reader provides a common interface for reading from a variety of sources. It has the following interface:
+//
+//	type Reader interface {
+//		Read(context.Context, string) (io.ReadSeekCloser, error)
+//		ReaderURI(string) string
+//	}
+//
+// Reader intstances are created either by calling a package-specific New{SOME_READER}Reader method or by invoking the
+// reader.NewReader method passing in a context.Context instance and a URI specific to the reader class. For example:
+//
+//	r, _ := reader.NewReader(ctx, "fs:///usr/local/data")
+//
+// Custom reader packages implement the reader.Reader interface and register their availability by calling the reader.RegisterRegister
+// method on initialization. For example:
+//
+//	func init() {
+//
+//		ctx := context.Background()
+//
+// 		err = RegisterReader(ctx, "file", NewFileReader)
+//
+//	 	if err != nil {
+// 			panic(err)
+// 		}
+// 	}
+//
+package reader

--- a/vendor/github.com/whosonfirst/go-reader/go.mod
+++ b/vendor/github.com/whosonfirst/go-reader/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/aaronland/go-roster v0.0.2
-	github.com/whosonfirst/go-ioutil v0.0.1
+	github.com/whosonfirst/go-ioutil v1.0.0
 )

--- a/vendor/github.com/whosonfirst/go-reader/go.sum
+++ b/vendor/github.com/whosonfirst/go-reader/go.sum
@@ -14,6 +14,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/whosonfirst/go-ioutil v0.0.1 h1:cCrEYen6NDvHfjzV2q4u/VB21u2kTOwDnUGRlMI8Z9o=
 github.com/whosonfirst/go-ioutil v0.0.1/go.mod h1:2dS1vWdAIkiHDvDF8fYyjv6k2NISmwaIjJJeEDBEdvg=
+github.com/whosonfirst/go-ioutil v1.0.0 h1:sYpgJx7Wsp76e7PFGa8KKQBvWQW3+HMCWSJbKdD5m14=
+github.com/whosonfirst/go-ioutil v1.0.0/go.mod h1:2dS1vWdAIkiHDvDF8fYyjv6k2NISmwaIjJJeEDBEdvg=
 github.com/whosonfirst/go-whosonfirst-cache v0.1.0 h1:ryWTsHj7gAEjwHC/WjsjROpFflsz3SCa7W9Qnk4EU7k=
 github.com/whosonfirst/go-whosonfirst-cache v0.1.0/go.mod h1:P5Tx34j2M50qX/kTfXY516apwGzJGkFSBYQI7TGArKw=
 github.com/whosonfirst/go-whosonfirst-cli v0.1.0 h1:Wwj9z0R/ryHmPmpVm5jCbXdG4agJzKMWXDtPVReN/KA=
@@ -24,6 +26,8 @@ github.com/whosonfirst/go-whosonfirst-sources v0.1.0 h1:JuKLa6KWke22jBfJ1pM9WQHo
 github.com/whosonfirst/go-whosonfirst-sources v0.1.0/go.mod h1:EUMHyGzUmqPPxlMmOp+28BFeoBdxxE0HCKRd67lkqGM=
 github.com/whosonfirst/go-whosonfirst-uri v0.1.0 h1:JMlpam0x1hVrFBMTAPY3edIHz7azfMK8lLI2kM9BgbI=
 github.com/whosonfirst/go-whosonfirst-uri v0.1.0/go.mod h1:8eaDVcc4v+HHHEDaRbApdmhPwM4/JQllw2PktvZcPVs=
+github.com/whosonfirst/go-whosonfirst-uri v1.0.1 h1:hVEDRuW9WhqvTksDi092OO9UecX7PAMDrD47KPEqAg0=
+github.com/whosonfirst/go-whosonfirst-uri v1.0.1/go.mod h1:8eaDVcc4v+HHHEDaRbApdmhPwM4/JQllw2PktvZcPVs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/github.com/whosonfirst/go-reader/reader.go
+++ b/vendor/github.com/whosonfirst/go-reader/reader.go
@@ -19,32 +19,6 @@ type Reader interface {
 	ReaderURI(context.Context, string) string
 }
 
-func NewService(ctx context.Context, uri string) (Reader, error) {
-
-	err := ensureReaderRoster()
-
-	if err != nil {
-		return nil, err
-	}
-
-	parsed, err := url.Parse(uri)
-
-	if err != nil {
-		return nil, err
-	}
-
-	scheme := parsed.Scheme
-
-	i, err := reader_roster.Driver(ctx, scheme)
-
-	if err != nil {
-		return nil, err
-	}
-
-	init_func := i.(ReaderInitializationFunc)
-	return init_func(ctx, uri)
-}
-
 func RegisterReader(ctx context.Context, scheme string, init_func ReaderInitializationFunc) error {
 
 	err := ensureReaderRoster()

--- a/vendor/github.com/whosonfirst/go-reader/stdin.go
+++ b/vendor/github.com/whosonfirst/go-reader/stdin.go
@@ -1,0 +1,51 @@
+package reader
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"github.com/whosonfirst/go-ioutil"
+	"io"
+	"os"
+)
+
+type StdinReader struct {
+	Reader
+}
+
+func init() {
+
+	ctx := context.Background()
+	err := RegisterReader(ctx, "stdin", NewStdinReader)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func NewStdinReader(ctx context.Context, uri string) (Reader, error) {
+
+	r := &StdinReader{}
+	return r, nil
+}
+
+func (r *StdinReader) Read(ctx context.Context, uri string) (io.ReadSeekCloser, error) {
+
+	var b bytes.Buffer
+	wr := bufio.NewWriter(&b)
+
+	_, err := io.Copy(wr, os.Stdin)
+
+	if err != nil {
+		return nil, err
+	}
+
+	wr.Flush()
+
+	br := bytes.NewReader(b.Bytes())
+	return ioutil.NewReadSeekCloser(br)
+}
+
+func (r *StdinReader) ReaderURI(ctx context.Context, uri string) string {
+	return "-"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/twpayne/go-geom/encoding/geojson
 github.com/twpayne/go-geom/encoding/wkt
 # github.com/whosonfirst/go-ioutil v1.0.0
 github.com/whosonfirst/go-ioutil
-# github.com/whosonfirst/go-reader v0.5.0
+# github.com/whosonfirst/go-reader v0.8.0
 ## explicit
 github.com/whosonfirst/go-reader
 # github.com/whosonfirst/go-rfc-5646 v0.1.0
@@ -153,6 +153,7 @@ github.com/whosonfirst/go-whosonfirst-sqlite-features/tables
 # github.com/whosonfirst/go-whosonfirst-sqlite-spr v0.0.6
 github.com/whosonfirst/go-whosonfirst-sqlite-spr
 # github.com/whosonfirst/go-whosonfirst-uri v1.0.1
+## explicit
 github.com/whosonfirst/go-whosonfirst-uri
 # github.com/whosonfirst/go-whosonfirst-writer v0.2.2
 ## explicit


### PR DESCRIPTION
as per discussion in https://github.com/whosonfirst/go-whosonfirst-exportify/issues/3#issuecomment-902193193 this PR updates the `whosonfirst/go-reader` dependency to the latest version.

```bash
go get -u github.com/whosonfirst/go-reader
go mod vendor
```

this might need another commit to get it working, I tried a few methods and I couldn't get it to output anything 🤷‍♂️ 

```bash
cat berlin.geojson \
  | ./bin/exportify \
    -reader-uri stdin:// -

2021/08/20 10:42:32 Failed to create writer for 'fs:///code/whosonfirst/go-whosonfirst-exportify/data', stat /code/whosonfirst/go-whosonfirst-exportify/data: no such file or directory

{exit 1}
```

```bash
cat berlin.geojson \
  | ./bin/exportify \
    -writer-uri stdout:// \
    -reader-uri stdin:// -
     
{no output, exit 0}
```

note: the order of commands affects the execution, I assumed `-writer-uri stdout://` was the default, but this seems to not be the case?

```bash
cat berlin.geojson \
  | ./bin/exportify \
    -reader-uri stdin:// - \
    -writer-uri stdout://

2021/08/20 10:46:23 Failed to create writer for 'fs:///code/whosonfirst/go-whosonfirst-exportify/data', stat /code/whosonfirst/go-whosonfirst-exportify/data: no such file or directory

{exit 1}
```

Regarding `stdin:// -` the `-` seems redundant here, do I need to include that or use it in for both stdin & stdout?