### PR TITLE
Add wof-create-record binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,15 @@ builds:
       - linux
       - windows
       - darwin
+  - id: wof-create-record
+    main: ./cmd/wof-create-record
+    binary: wof-create-record
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
   - id: wof-deprecate
     main: ./cmd/wof-deprecate
     binary: wof-deprecate
@@ -131,20 +140,19 @@ builds:
 universal_binaries:
   - replace: true
 archives:
-  -
-    format: binary
+  - format: binary
     replacements:
       386: 32bit
       amd64: 64bit
       darwin: macos
       all: universal
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ cli:
 	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-assign-parent cmd/wof-assign-parent/main.go
 	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-exportify cmd/wof-exportify/main.go
 	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-create cmd/wof-create/main.go
+	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-create-record cmd/wof-create-record/main.go
 	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-deprecate cmd/wof-deprecate/main.go
 	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-cessate cmd/wof-cessate/main.go
 	go build -mod $(GOMOD) -ldflags="-s -w" -o bin/wof-superseded-by cmd/wof-superseded-by/main.go

--- a/cmd/wof-create-record/main.go
+++ b/cmd/wof-create-record/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sfomuseum/go-flags/flagset"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+	"github.com/whosonfirst/go-reader"
+	export "github.com/whosonfirst/go-whosonfirst-export/v2"
+	wofReader "github.com/whosonfirst/go-whosonfirst-reader"
+	wofWriter "github.com/whosonfirst/go-whosonfirst-writer/v3"
+	"github.com/whosonfirst/go-writer/v3"
+)
+
+func main() {
+	fs := flagset.NewFlagSet("create")
+
+	parentReaderURI := fs.String("parent-reader-uri", "", "A valid whosonfirst/go-reader URI")
+	parentID := fs.Int64("parent-wof-id", -1, "An optional WOF ID which the created record should be parented by")
+	writerURI := fs.String("writer-uri", "", "A valid whosonfirst/go-writer URI")
+	exporterURI := fs.String("exporter-uri", "whosonfirst://", "A valid whosonfirst/go-whosonfirst-export URI.")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Create a new WOF record from a partially prepared record. Useful when you have a new record, but need to give it an ID, place it into the hierarchy and write it into a repo.\n\n")
+		fmt.Fprintf(os.Stderr, "Usage:\n\t %s [options] file [file ...]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Valid options are:\n")
+		fs.PrintDefaults()
+	}
+
+	flagset.Parse(fs)
+
+	// Fail if there's no files
+	if fs.NArg() < 1 {
+		fs.Usage()
+		log.Fatalf("No files provided")
+	}
+
+	ctx := context.Background()
+
+	// Setup the exporter
+	ex, err := export.NewExporter(ctx, *exporterURI)
+	if err != nil {
+		log.Fatalf("Failed create exporter for '%s', %v", *exporterURI, err)
+	}
+
+	// Setup the writer
+	wr, err := writer.NewWriter(ctx, *writerURI)
+	if err != nil {
+		log.Fatalf("Failed create writer for '%s', %v", *writerURI, err)
+	}
+
+	files := fs.Args()
+
+	for _, file := range files {
+		log.Print(file)
+
+		bytes, err := os.ReadFile(file)
+		if err != nil {
+			log.Fatalf("Unable to read file: %s, %v", file, err)
+		}
+
+		// If -parent-id is provided, attempt to set the hierarchy and other details from the parent
+		if *parentID > 0 {
+			if *parentReaderURI == "" {
+				log.Fatalf("No parent reader URI provided")
+			}
+
+			parentReader, err := reader.NewReader(ctx, *parentReaderURI)
+			if err != nil {
+				log.Fatalf("Failed to create reader for '%s', %v", *parentReaderURI, err)
+			}
+
+			parentBytes, err := wofReader.LoadBytes(ctx, parentReader, *parentID)
+			if err != nil {
+				log.Fatalf("Failed to load parent record (%d), %v", *parentID, err)
+			}
+
+			to_copy := []string{
+				"properties.wof:hierarchy",
+				"properties.wof:country",
+			}
+
+			for _, path := range to_copy {
+				rsp := gjson.GetBytes(parentBytes, path)
+				bytes, err = sjson.SetBytes(bytes, path, rsp.Value())
+
+				if err != nil {
+					log.Fatalf("Failed to copy '%s' parent value, %v", path, err)
+				}
+			}
+		}
+
+		exportBytes, err := ex.Export(ctx, bytes)
+		if err != nil {
+			log.Fatalf("Failed to export '%s', %v", file, err)
+		}
+
+		_, err = wofWriter.WriteBytes(ctx, wr, exportBytes)
+		if err != nil {
+			log.Fatalf("Failed to write '%s', %v", file, err)
+		}
+	}
+
+}


### PR DESCRIPTION
Useful binary for taking a partially prepared record file and assigning it an ID, placing it into the hierarchy and writing it into a repo.